### PR TITLE
Remove broken Voco link from the index page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -108,7 +108,6 @@ if (navigator.doNotTrack !== '1') {
   </div>
 </div>
 <div class="container my-3 py-3">
-  <h5>Want to keep up with Swift news on your smart speaker? <a href="https://askvoco.com" id="askvocolink">Follow us on Voco.</a></h5>
   <form action="https://swiftwasm.us20.list-manage.com/subscribe/post?u=34f61d506587d4af83fd2c79f&amp;id=a452cde3d3" method="post" id="mc-embedded-subscribe-form-inline" name="mc-embedded-subscribe-form-inline" class="validate" target="_blank">
     Or sign up for our mailing list:
     <input type="email" value="" name="EMAIL" class="required email form-control-smm" id="mce-EMAIL" placeholder="Email">


### PR DESCRIPTION
I've confirmed with @zhuowei that this link can be removed as it doesn't work.