### PR TITLE
Add a link to SwiftWasm Pad in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -122,6 +122,8 @@
   <div class="container shadow rounded border my-3 py-3">
     <h2>Try Swift on WebAssembly now</h2>
     <p>Compile Swift in the cloud and run in your browser.</p>
+    <p>Are you looking for a more powerful playground environment with access to the SwiftUI API in you browser?
+      Try our <a href="https://pad.swiftwasm.org">SwiftWasm Pad</a>!</p>
     <noscript>Please enable JavaScript to use the Try it Now area.</noscript>
     <div class="row">
       <div class="col-lg">


### PR DESCRIPTION
Now that SwiftWasm Pad is live on a proper subdomain and is a part of the SwiftWasm org, it's time link it to from `index.html`! 🎉