### PR TITLE
Add link to the SwiftWasm Discord server

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -91,6 +91,7 @@
             </string>
           </p>
           <p><a href="https://blog.swiftwasm.org">Blog</a></p>
+          <p><a href="https://discord.gg/55GCuuFN">Discord</a></p>
           <p><a href="https://book.swiftwasm.org">Documentation</a></p>
           <p><a href="https://github.com/swiftwasm/swift">Source on GitHub</a> </p>
           <p><a href="https://github.com/apple/swift/pull/24684">View our Swift pull request</a></p>


### PR DESCRIPTION
By popular request, here's a link to our shiny new Discord server dedicated to SwiftWasm.