### PR TITLE
Link to the browser apps guide directly from `index.html`

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -130,8 +130,11 @@
   <div class="container shadow rounded border my-3 py-3">
     <h2>Try Swift on WebAssembly now</h2>
     <p>Compile Swift in the cloud and run in your browser.</p>
-    <p>Are you looking for a more powerful playground environment with access to the SwiftUI API in you browser?
+    <p>Check out <a href="https://book.swiftwasm.org/getting-started/browser-app.html">how to get started</a> and create
+      a browser app written in Swift on your local machine.</p>
+    <p>Are you looking for a powerful playground environment with access to the SwiftUI API in you browser?
       Try our <a href="https://pad.swiftwasm.org">SwiftWasm Pad</a>!</p>
+    <p>You can also build and run short snippets right here in the text input below.</p>
     <noscript>Please enable JavaScript to use the Try it Now area.</noscript>
     <div class="row">
       <div class="col-lg">


### PR DESCRIPTION
I think this is a more direct path for people to get started leading straight from the index page.